### PR TITLE
Add license metadata to PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     description='Auton Lab TA1 primitives',
     author=read_package_variable('__author__'),
     author_email=read_package_variable('__author_email__'),
+    license='MIT',
     packages=find_packages(exclude=['docs', 'tests*']),
     install_requires=[
         'd3m',


### PR DESCRIPTION
The package shows as `UNKNOWN` right now and people have to come to the repository to find the LICENSE file.